### PR TITLE
Fixed bdist_wheel bug by removing runtime dependency on setuptools_scm

### DIFF
--- a/esmigrate/commons/__init__.py
+++ b/esmigrate/commons/__init__.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
+
+if sys.version_info < (3, 8):  # pragma: no cover
+    from importlib_metadata import version as get_version
+else:  # pragma: no cover
+    from importlib.metadata import version as get_version
 
 import appdirs
-from setuptools_scm import get_version
 
 from esmigrate.commons.command import Command
 from esmigrate.commons.helpers import (
@@ -16,8 +21,7 @@ JSON_HEADER = {"Content-Type": "application/json"}
 NDJSON_HEADER = {"Content-Type": "application/x-ndjson"}
 
 appname = "elastic-migrate"
-version = get_version(root="../../", relative_to=__file__)
-version_short = version.split("+")[0]
+version = get_version(appname)
 
 title = f"""
   ███████╗███████╗    ███╗   ███╗██╗ ██████╗ ██████╗  █████╗ ████████╗███████╗
@@ -25,7 +29,7 @@ title = f"""
   █████╗  ███████╗    ██╔████╔██║██║██║  ███╗██████╔╝███████║   ██║   █████╗
   ██╔══╝  ╚════██║    ██║╚██╔╝██║██║██║   ██║██╔══██╗██╔══██║   ██║   ██╔══╝
   ███████╗███████║    ██║ ╚═╝ ██║██║╚██████╔╝██║  ██║██║  ██║   ██║   ███████╗
-  ╚══════╝╚══════╝    ╚═╝     ╚═╝╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚══════╝  {version_short}
+  ╚══════╝╚══════╝    ╚═╝     ╚═╝╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚══════╝  {version}
   Elasticsearch migrations made easy!
 """
 
@@ -38,7 +42,6 @@ __all__ = [
     "NDJSON_HEADER",
     "appname",
     "version",
-    "version_short",
     "title",
     "local_config_file_path",
     "user_config_file_path",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ distlib==0.3.1
 filelock==3.0.12
 identify==1.4.21
 idna==2.10
+importlib-metadata==1.7.0
 jsonschema==3.2.0
 more-itertools==8.4.0
 nodeenv==1.4.0
@@ -34,3 +35,4 @@ urllib3==1.25.9
 validator-collection==1.4.2
 virtualenv==20.0.26
 wcwidth==0.2.5
+zipp==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup_dependencies = [
 ]
 
 install_dependencies = [
-    "setuptools-scm",
+    "importlib-metadata;python_version<'3.8'",
     "appdirs",
     "click",
     "click-log",


### PR DESCRIPTION
### Related Issues
Fixes #7 

### Proposed Changes
- Removed setuptools_scm runtime dependency
- Added backport dependency on importlib-metadata for python versions older than 3.8

### Checklist
- [x] Tests
- [x] Coverages
- [ ] Documentations
